### PR TITLE
fix(go): override default HTTP client timeout

### DIFF
--- a/go/db_factory.go
+++ b/go/db_factory.go
@@ -64,7 +64,7 @@ func (f *TrinoDBFactory) registerCustomClientForTimeout(dsn string) (string, err
 		return "", fmt.Errorf("failed to parse DSN: %v", err)
 	}
 
-	const httpClientName = "abdc_trino_timeout"
+	const httpClientName = "adbc_trino_timeout"
 
 	timeout := trino.DefaultQueryTimeout
 	if cfg.QueryTimeout != nil {


### PR DESCRIPTION
## What's Changed

When query_timeout is set in DSN, automatically create and register a custom HTTP client with matching timeout. This prevents HTTP-level timeouts during long-running queries.

Closes #39 .
