### PR TITLE
chore: update pytest.ini to latest state

### DIFF
--- a/go/validation/pytest.ini
+++ b/go/validation/pytest.ini
@@ -23,3 +23,4 @@ markers =
 filterwarnings =
     error
     ignore:record_property is incompatible with junit_family:pytest.PytestWarning
+    ignore:Cannot disable autocommit; conn will not be DB-API 2.0 compliant:adbc_driver_manager._lib.Warning


### PR DESCRIPTION
## What's Changed

Updates pytest.ini to match how we have it set up for other repos. Notably, we treat warnings as errors now.
