### PR TITLE
fix(go): support tls connections and validate over tls

### DIFF
--- a/go/.env.linux
+++ b/go/.env.linux
@@ -12,10 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TRINO_DSN="http://test@localhost:8080?catalog=memory&schema=default"
+# General driver validation uses TRINO_DSN. The URI-specific tests in
+# validation/tests/trino/test_uri.py build their own connection strings from
+# the TRINO_HOST/TRINO_PORT/TRINO_CATALOG/TRINO_SCHEMA/TRINO_SSL_* variables.
+
+TRINO_DSN="https://test@localhost:8443?catalog=memory&schema=default&SSLCertPath=${PWD}/ci/docker/certs/ca.crt"
 TRINO_HOST="localhost"
-TRINO_PORT="8080"
+TRINO_PORT="8443"
 TRINO_CATALOG="memory"
 TRINO_SCHEMA="default"
+TRINO_SSL_MODE="https"
+TRINO_SSL_CERT_PATH="${PWD}/ci/docker/certs/ca.crt"
 TRINO_USERNAME="test"
-TRINO_PASSWORD="password"

--- a/go/ci/docker/certs/generate-certs.sh
+++ b/go/ci/docker/certs/generate-certs.sh
@@ -98,5 +98,6 @@ run_openssl pkcs12 \
 
 cp "${TMP_CA_CERT}" "${CA_CERT}"
 cp "${TMP_KEYSTORE}" "${KEYSTORE}"
+chmod 0644 "${CA_CERT}" "${KEYSTORE}"
 
 echo "Generated Trino TLS assets in ${CERT_DIR}"

--- a/go/ci/docker/certs/generate-certs.sh
+++ b/go/ci/docker/certs/generate-certs.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Copyright (c) 2026 ADBC Drivers Contributors
 #
@@ -15,57 +15,38 @@
 # limitations under the License.
 
 # Generate the self-signed CA certificate and PKCS#12 keystore used by the
-# local Trino Docker Compose HTTPS setup before the services start.
+# local Trino Docker Compose HTTPS setup.
 
-set -euo pipefail
+set -eu
 
-SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
-GO_DIR=$(cd -- "${SCRIPT_DIR}/../.." && pwd)
-CERT_DIR="${GO_DIR}/ci/docker/certs"
-
+CERT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 CA_CONFIG="${CERT_DIR}/openssl-ca.cnf"
 SERVER_CONFIG="${CERT_DIR}/openssl-server.cnf"
 
 CA_CERT="${CERT_DIR}/ca.crt"
 KEYSTORE="${CERT_DIR}/localhost.p12"
 
-FORCE_REGENERATE="${TRINO_FORCE_REGENERATE_CERTS:-0}"
-PLATFORM="${2:-}"
-
-if [[ -f "${CA_CERT}" && -f "${KEYSTORE}" && "${FORCE_REGENERATE}" != "1" ]]; then
+if [ -f "${CA_CERT}" ] && [ -f "${KEYSTORE}" ] && [ "${TRINO_FORCE_REGENERATE_CERTS:-0}" != "1" ]; then
   echo "Trino TLS assets already exist"
   exit 0
 fi
 
-if ! command -v openssl >/dev/null 2>&1; then
-  if [[ "${PLATFORM}" == "linux" ]]; then
-    echo "openssl is required to generate Trino TLS assets" >&2
-    exit 1
-  fi
-
-  echo "Skipping Trino TLS asset generation because openssl is not available"
-  exit 0
-fi
-
-if [[ ! -f "${CA_CONFIG}" || ! -f "${SERVER_CONFIG}" ]]; then
+if [ ! -f "${CA_CONFIG}" ] || [ ! -f "${SERVER_CONFIG}" ]; then
   echo "Missing OpenSSL config under ${CERT_DIR}" >&2
   exit 1
 fi
-
-mkdir -p "${CERT_DIR}"
 
 TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/trino-certs.XXXXXX")
 cleanup() {
   rm -rf "${TMP_DIR}"
 }
-trap cleanup EXIT
+trap cleanup EXIT INT TERM
 
 run_openssl() {
-  local log_file="${TMP_DIR}/openssl.log"
-
+  log_file="${TMP_DIR}/openssl.log"
   if ! openssl "$@" > /dev/null 2>"${log_file}"; then
     cat "${log_file}" >&2
-    return 1
+    exit 1
   fi
 }
 

--- a/go/ci/docker/certs/openssl-ca.cnf
+++ b/go/ci/docker/certs/openssl-ca.cnf
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 ADBC Drivers Contributors
+# Copyright (c) 2026 ADBC Drivers Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,11 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pixi environments
-.pixi
-*.egg-info
+# OpenSSL config for the self-signed CA certificate used to trust the local
+# Trino HTTPS endpoint during development and CI validation.
 
-generated/
-validation-report.xml
-ci/docker/certs/ca.crt
-ci/docker/certs/localhost.p12
+[ req ]
+default_bits = 2048
+prompt = no
+default_md = sha256
+distinguished_name = dn
+x509_extensions = v3_ca
+
+[ dn ]
+CN = Trino Local Test CA
+
+[ v3_ca ]
+basicConstraints = critical, CA:true
+keyUsage = critical, keyCertSign, cRLSign
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer

--- a/go/ci/docker/certs/openssl-server.cnf
+++ b/go/ci/docker/certs/openssl-server.cnf
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 ADBC Drivers Contributors
+# Copyright (c) 2026 ADBC Drivers Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,11 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pixi environments
-.pixi
-*.egg-info
+# OpenSSL config for the localhost server certificate signed by the local test
+# CA and packaged into the PKCS#12 keystore mounted into the Trino container.
 
-generated/
-validation-report.xml
-ci/docker/certs/ca.crt
-ci/docker/certs/localhost.p12
+[ req ]
+default_bits = 2048
+prompt = no
+default_md = sha256
+distinguished_name = dn
+req_extensions = v3_req
+
+[ dn ]
+CN = localhost
+
+[ v3_req ]
+basicConstraints = critical, CA:false
+keyUsage = critical, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+
+[ alt_names ]
+DNS.1 = localhost
+IP.1 = 127.0.0.1

--- a/go/ci/docker/trino/config.properties
+++ b/go/ci/docker/trino/config.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 ADBC Drivers Contributors
+# Copyright (c) 2026 ADBC Drivers Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pixi environments
-.pixi
-*.egg-info
-
-generated/
-validation-report.xml
-ci/docker/certs/ca.crt
-ci/docker/certs/localhost.p12
+# Keep HTTP enabled for the existing validation flow, and add HTTPS for
+# self-signed certificate testing from the host.
+coordinator=true
+node-scheduler.include-coordinator=true
+http-server.http.port=8080
+http-server.https.enabled=true
+http-server.https.port=8443
+http-server.https.keystore.path=/etc/trino/certs/localhost.p12
+http-server.https.keystore.key=trino-dev
+discovery.uri=http://localhost:8080

--- a/go/ci/scripts/pre-build.sh
+++ b/go/ci/scripts/pre-build.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2026 ADBC Drivers Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Generate the self-signed CA certificate and PKCS#12 keystore used by the
+# local Trino Docker Compose HTTPS setup before the services start.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+GO_DIR=$(cd -- "${SCRIPT_DIR}/../.." && pwd)
+CERT_DIR="${GO_DIR}/ci/docker/certs"
+
+CA_CONFIG="${CERT_DIR}/openssl-ca.cnf"
+SERVER_CONFIG="${CERT_DIR}/openssl-server.cnf"
+
+CA_CERT="${CERT_DIR}/ca.crt"
+KEYSTORE="${CERT_DIR}/localhost.p12"
+
+FORCE_REGENERATE="${TRINO_FORCE_REGENERATE_CERTS:-0}"
+PLATFORM="${2:-}"
+
+if [[ -f "${CA_CERT}" && -f "${KEYSTORE}" && "${FORCE_REGENERATE}" != "1" ]]; then
+  echo "Trino TLS assets already exist"
+  exit 0
+fi
+
+if ! command -v openssl >/dev/null 2>&1; then
+  if [[ "${PLATFORM}" == "linux" ]]; then
+    echo "openssl is required to generate Trino TLS assets" >&2
+    exit 1
+  fi
+
+  echo "Skipping Trino TLS asset generation because openssl is not available"
+  exit 0
+fi
+
+if [[ ! -f "${CA_CONFIG}" || ! -f "${SERVER_CONFIG}" ]]; then
+  echo "Missing OpenSSL config under ${CERT_DIR}" >&2
+  exit 1
+fi
+
+mkdir -p "${CERT_DIR}"
+
+TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/trino-certs.XXXXXX")
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+run_openssl() {
+  local log_file="${TMP_DIR}/openssl.log"
+
+  if ! openssl "$@" > /dev/null 2>"${log_file}"; then
+    cat "${log_file}" >&2
+    return 1
+  fi
+}
+
+CA_KEY="${TMP_DIR}/ca.key"
+SERVER_KEY="${TMP_DIR}/localhost.key"
+SERVER_CSR="${TMP_DIR}/localhost.csr"
+CA_SERIAL="${TMP_DIR}/ca.srl"
+TMP_CA_CERT="${TMP_DIR}/ca.crt"
+TMP_SERVER_CERT="${TMP_DIR}/localhost.crt"
+TMP_KEYSTORE="${TMP_DIR}/localhost.p12"
+
+run_openssl req \
+  -x509 \
+  -newkey rsa:2048 \
+  -days 3650 \
+  -nodes \
+  -keyout "${CA_KEY}" \
+  -out "${TMP_CA_CERT}" \
+  -config "${CA_CONFIG}"
+
+run_openssl req \
+  -new \
+  -newkey rsa:2048 \
+  -nodes \
+  -keyout "${SERVER_KEY}" \
+  -out "${SERVER_CSR}" \
+  -config "${SERVER_CONFIG}"
+
+run_openssl x509 \
+  -req \
+  -days 3650 \
+  -in "${SERVER_CSR}" \
+  -CA "${TMP_CA_CERT}" \
+  -CAkey "${CA_KEY}" \
+  -CAcreateserial \
+  -CAserial "${CA_SERIAL}" \
+  -out "${TMP_SERVER_CERT}" \
+  -extfile "${SERVER_CONFIG}" \
+  -extensions v3_req
+
+run_openssl pkcs12 \
+  -export \
+  -out "${TMP_KEYSTORE}" \
+  -inkey "${SERVER_KEY}" \
+  -in "${TMP_SERVER_CERT}" \
+  -certfile "${TMP_CA_CERT}" \
+  -name trino-dev \
+  -passout pass:trino-dev
+
+cp "${TMP_CA_CERT}" "${CA_CERT}"
+cp "${TMP_KEYSTORE}" "${KEYSTORE}"
+
+echo "Generated Trino TLS assets in ${CERT_DIR}"

--- a/go/compose.yaml
+++ b/go/compose.yaml
@@ -36,7 +36,11 @@ services:
       start_period: 20s
     ports:
       - 8080:8080
+      - 8443:8443
     volumes:
+      - "./ci/docker/trino/config.properties:/etc/trino/config.properties:ro"
+      - "./ci/docker/certs/localhost.p12:/etc/trino/certs/localhost.p12:ro"
+      - "./ci/docker/certs/ca.crt:/etc/trino/certs/ca.crt:ro"
       # Add a second 'memory' catalog named 'secondmemory'
       - "./ci/docker/catalog/secondmemory.properties:/etc/trino/catalog/secondmemory.properties:ro"
 

--- a/go/compose.yaml
+++ b/go/compose.yaml
@@ -24,10 +24,23 @@ services:
       trino-init:
         condition: service_completed_successfully
 
+  cert-generator:
+    image: alpine:latest
+    entrypoint: ["/bin/sh", "-ec"]
+    command:
+      - |
+        apk add --no-cache openssl >/dev/null
+        /bin/sh /work/certs/generate-certs.sh
+    volumes:
+      - "./ci/docker/certs:/work/certs"
+
   trino:
     image: trinodb/trino:latest
     environment:
       TRINO_NODE_ENVIRONMENT: development
+    depends_on:
+      cert-generator:
+        condition: service_completed_successfully
     healthcheck:
       test: ["CMD-SHELL", "/usr/lib/trino/bin/health-check"]
       interval: 5s
@@ -39,8 +52,7 @@ services:
       - 8443:8443
     volumes:
       - "./ci/docker/trino/config.properties:/etc/trino/config.properties:ro"
-      - "./ci/docker/certs/localhost.p12:/etc/trino/certs/localhost.p12:ro"
-      - "./ci/docker/certs/ca.crt:/etc/trino/certs/ca.crt:ro"
+      - "./ci/docker/certs:/etc/trino/certs:ro"
       # Add a second 'memory' catalog named 'secondmemory'
       - "./ci/docker/catalog/secondmemory.properties:/etc/trino/catalog/secondmemory.properties:ro"
 

--- a/go/db_factory.go
+++ b/go/db_factory.go
@@ -16,21 +16,22 @@ package trino
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
+	"crypto/x509"
 	"database/sql"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
-	"sync"
+	"time"
 
 	"github.com/adbc-drivers/driverbase-go/sqlwrapper"
 	"github.com/apache/arrow-adbc/go/adbc"
 	"github.com/trinodb/trino-go-client/trino"
 )
-
-var httpClientOnce sync.Once
 
 // TrinoDBFactory provides Trino-specific database connection creation.
 // It handles Trino DSN formatting and connection parameters.
@@ -73,39 +74,86 @@ func (f *TrinoDBFactory) registerCustomClientForTimeout(dsn string) (string, err
 		return "", fmt.Errorf("failed to parse DSN: %v", err)
 	}
 
-	const httpClientName = "adbc_trino_timeout"
-
 	timeout := trino.DefaultQueryTimeout
 	if cfg.QueryTimeout != nil {
 		timeout = *cfg.QueryTimeout
 	}
 
-	var httpClientErr error
-	httpClientOnce.Do(func() {
-		transport := http.DefaultTransport.(*http.Transport).Clone()
-		transport.ResponseHeaderTimeout = timeout
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.ResponseHeaderTimeout = timeout
 
-		// Configure TLS if certificate verification should be skipped
-		if skipVerification {
-			transport.TLSClientConfig = &tls.Config{
-				InsecureSkipVerify: true,
-			}
-		}
+	tlsConfig, err := buildTLSConfig(transport.TLSClientConfig, cfg, skipVerification)
+	if err != nil {
+		return "", err
+	}
+	if tlsConfig != nil {
+		transport.TLSClientConfig = tlsConfig
+	}
 
-		customClient := &http.Client{
-			Timeout:   timeout,
-			Transport: transport,
-		}
-		httpClientErr = trino.RegisterCustomClient(httpClientName, customClient)
-	})
-
-	if httpClientErr != nil {
-		return "", fmt.Errorf("failed to register custom HTTP client: %v", httpClientErr)
+	httpClientName := customClientName(timeout, skipVerification, cfg.SSLCertPath, cfg.SSLCert)
+	customClient := &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+	}
+	if err := trino.RegisterCustomClient(httpClientName, customClient); err != nil {
+		return "", fmt.Errorf("failed to register custom HTTP client: %v", err)
 	}
 
 	cfg.CustomClientName = httpClientName
+	// The custom HTTP client now owns TLS verification/trust configuration.
+	cfg.SSLCertPath = ""
+	cfg.SSLCert = ""
 
 	return cfg.FormatDSN()
+}
+
+func buildTLSConfig(base *tls.Config, cfg *trino.Config, skipVerification bool) (*tls.Config, error) {
+	tlsConfig := cloneTLSConfig(base)
+
+	if skipVerification {
+		tlsConfig.InsecureSkipVerify = true
+	}
+
+	if cfg.SSLCert != "" || cfg.SSLCertPath != "" {
+		cert, err := loadSSLCert(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load SSL certificate: %v", err)
+		}
+
+		certPool := x509.NewCertPool()
+		if !certPool.AppendCertsFromPEM(cert) {
+			return nil, fmt.Errorf("failed to parse SSL certificate")
+		}
+		tlsConfig.RootCAs = certPool
+	}
+
+	if skipVerification || cfg.SSLCert != "" || cfg.SSLCertPath != "" {
+		return tlsConfig, nil
+	}
+
+	return nil, nil
+}
+
+func cloneTLSConfig(base *tls.Config) *tls.Config {
+	if base == nil {
+		return &tls.Config{}
+	}
+	return base.Clone()
+}
+
+func loadSSLCert(cfg *trino.Config) ([]byte, error) {
+	if cfg.SSLCert != "" {
+		return []byte(cfg.SSLCert), nil
+	}
+	return os.ReadFile(cfg.SSLCertPath)
+}
+
+func customClientName(timeout time.Duration, skipVerification bool, sslCertPath, sslCert string) string {
+	sum := sha256.Sum256(fmt.Appendf(nil,
+		"timeout=%s|skip_verification=%t|ssl_cert_path=%s|ssl_cert=%s",
+		timeout, skipVerification, sslCertPath, sslCert,
+	))
+	return fmt.Sprintf("adbc_trino_timeout_%x", sum[:8])
 }
 
 // buildTrinoDSN constructs a Trino DSN from the provided options.

--- a/go/db_factory.go
+++ b/go/db_factory.go
@@ -26,6 +26,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/adbc-drivers/driverbase-go/sqlwrapper"
@@ -36,6 +37,15 @@ import (
 // TrinoDBFactory provides Trino-specific database connection creation.
 // It handles Trino DSN formatting and connection parameters.
 type TrinoDBFactory struct{}
+
+type customClientRegistration struct {
+	mu         sync.Mutex
+	registered bool
+}
+
+var (
+	customClientRegistrations sync.Map
+)
 
 // NewTrinoDBFactory creates a new TrinoDBFactory.
 func NewTrinoDBFactory() *TrinoDBFactory {
@@ -95,7 +105,7 @@ func (f *TrinoDBFactory) registerCustomClientForTimeout(dsn string) (string, err
 		Timeout:   timeout,
 		Transport: transport,
 	}
-	if err := trino.RegisterCustomClient(httpClientName, customClient); err != nil {
+	if err := ensureCustomClientRegistered(httpClientName, customClient); err != nil {
 		return "", fmt.Errorf("failed to register custom HTTP client: %v", err)
 	}
 
@@ -120,7 +130,10 @@ func buildTLSConfig(base *tls.Config, cfg *trino.Config, skipVerification bool) 
 			return nil, fmt.Errorf("failed to load SSL certificate: %v", err)
 		}
 
-		certPool := x509.NewCertPool()
+		certPool, err := rootCertPool(tlsConfig.RootCAs)
+		if err != nil {
+			return nil, err
+		}
 		if !certPool.AppendCertsFromPEM(cert) {
 			return nil, fmt.Errorf("failed to parse SSL certificate")
 		}
@@ -141,6 +154,21 @@ func cloneTLSConfig(base *tls.Config) *tls.Config {
 	return base.Clone()
 }
 
+func rootCertPool(base *x509.CertPool) (*x509.CertPool, error) {
+	if base != nil {
+		return base.Clone(), nil
+	}
+
+	certPool, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load system cert pool: %v", err)
+	}
+	if certPool == nil {
+		return x509.NewCertPool(), nil
+	}
+	return certPool, nil
+}
+
 func loadSSLCert(cfg *trino.Config) ([]byte, error) {
 	if cfg.SSLCert != "" {
 		return []byte(cfg.SSLCert), nil
@@ -154,6 +182,25 @@ func customClientName(timeout time.Duration, skipVerification bool, sslCertPath,
 		timeout, skipVerification, sslCertPath, sslCert,
 	))
 	return fmt.Sprintf("adbc_trino_timeout_%x", sum[:8])
+}
+
+func ensureCustomClientRegistered(name string, client *http.Client) error {
+	registrationAny, _ := customClientRegistrations.LoadOrStore(name, &customClientRegistration{})
+	registration := registrationAny.(*customClientRegistration)
+
+	registration.mu.Lock()
+	defer registration.mu.Unlock()
+
+	if registration.registered {
+		return nil
+	}
+
+	if err := trino.RegisterCustomClient(name, client); err != nil {
+		return err
+	}
+
+	registration.registered = true
+	return nil
 }
 
 // buildTrinoDSN constructs a Trino DSN from the provided options.

--- a/go/db_factory.go
+++ b/go/db_factory.go
@@ -16,7 +16,6 @@ package trino
 
 import (
 	"context"
-	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
 	"database/sql"
@@ -177,11 +176,10 @@ func loadSSLCert(cfg *trino.Config) ([]byte, error) {
 }
 
 func customClientName(timeout time.Duration, skipVerification bool, sslCertPath, sslCert string) string {
-	sum := sha256.Sum256(fmt.Appendf(nil,
+	return fmt.Sprintf(
 		"timeout=%s|skip_verification=%t|ssl_cert_path=%s|ssl_cert=%s",
 		timeout, skipVerification, sslCertPath, sslCert,
-	))
-	return fmt.Sprintf("adbc_trino_timeout_%x", sum[:8])
+	)
 }
 
 func ensureCustomClientRegistered(name string, client *http.Client) error {

--- a/go/db_factory.go
+++ b/go/db_factory.go
@@ -26,7 +26,6 @@ import (
 	"os"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/adbc-drivers/driverbase-go/sqlwrapper"
 	"github.com/apache/arrow-adbc/go/adbc"
@@ -99,7 +98,10 @@ func (f *TrinoDBFactory) registerCustomClientForTimeout(dsn string) (string, err
 		transport.TLSClientConfig = tlsConfig
 	}
 
-	httpClientName := customClientName(timeout, skipVerification, cfg.SSLCertPath, cfg.SSLCert)
+	httpClientName := fmt.Sprintf(
+		"timeout=%s|skip_verification=%t|ssl_cert_path=%s|ssl_cert=%s",
+		timeout, skipVerification, cfg.SSLCertPath, cfg.SSLCert,
+	)
 	customClient := &http.Client{
 		Timeout:   timeout,
 		Transport: transport,
@@ -173,13 +175,6 @@ func loadSSLCert(cfg *trino.Config) ([]byte, error) {
 		return []byte(cfg.SSLCert), nil
 	}
 	return os.ReadFile(cfg.SSLCertPath)
-}
-
-func customClientName(timeout time.Duration, skipVerification bool, sslCertPath, sslCert string) string {
-	return fmt.Sprintf(
-		"timeout=%s|skip_verification=%t|ssl_cert_path=%s|ssl_cert=%s",
-		timeout, skipVerification, sslCertPath, sslCert,
-	)
 }
 
 func ensureCustomClientRegistered(name string, client *http.Client) error {

--- a/go/validation/README.md
+++ b/go/validation/README.md
@@ -19,20 +19,37 @@
 1. Start the Docker container:
 
    ```shell
-   ./ci/scripts/pre-build.sh test linux amd64
    docker compose up --detach --wait
    ```
 2. Set the environment variable:
 
    ```shell
+   export TRINO_HOST="localhost"
+   export TRINO_PORT="8080"
+   export TRINO_CATALOG="memory"
+   export TRINO_SCHEMA="default"
+   export TRINO_SSL_MODE="http"
+   export TRINO_SSL_CERT_PATH="/path/to/ci/docker/certs/ca.crt"
+   export TRINO_USERNAME="test"
+   ```
+
+   For HTTP:
+
+   ```shell
    export TRINO_DSN="http://test@localhost:8080?catalog=memory&schema=default"
    ```
 
-   For the local HTTPS setup with the self-signed test CA:
+   For the local HTTPS setup with the self-signed test CA, switch `TRINO_PORT`
+   to `8443`, `TRINO_SSL_MODE` to `https`, and use:
 
    ```shell
    export TRINO_DSN="https://test@localhost:8443?catalog=memory&schema=default&SSLCertPath=/path/to/ci/docker/certs/ca.crt"
    ```
+
+   `TRINO_DSN` is used by the general validation suite. The URI-focused tests in
+   `validation/tests/trino/test_uri.py` build their own connection strings from
+   the `TRINO_HOST`, `TRINO_PORT`, `TRINO_CATALOG`, `TRINO_SCHEMA`,
+   `TRINO_SSL_MODE`, `TRINO_SSL_CERT_PATH`, and `TRINO_USERNAME` variables.
 3. Run the tests:
 
    ```shell

--- a/go/validation/README.md
+++ b/go/validation/README.md
@@ -19,12 +19,19 @@
 1. Start the Docker container:
 
    ```shell
+   ./ci/scripts/pre-build.sh test linux amd64
    docker compose up --detach --wait
    ```
 2. Set the environment variable:
 
    ```shell
    export TRINO_DSN="http://test@localhost:8080?catalog=memory&schema=default"
+   ```
+
+   For the local HTTPS setup with the self-signed test CA:
+
+   ```shell
+   export TRINO_DSN="https://test@localhost:8443?catalog=memory&schema=default&SSLCertPath=/path/to/ci/docker/certs/ca.crt"
    ```
 3. Run the tests:
 

--- a/go/validation/tests/trino/conftest.py
+++ b/go/validation/tests/trino/conftest.py
@@ -13,8 +13,16 @@
 # limitations under the License.
 
 import os
+import urllib.parse
 
 import pytest
+
+
+def require_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        pytest.skip(f"{name} must be set for Trino URI validation tests")
+    return value
 
 
 def pytest_generate_tests(metafunc) -> None:
@@ -29,55 +37,116 @@ def pytest_generate_tests(metafunc) -> None:
 @pytest.fixture(scope="session")
 def trino_host() -> str:
     """Trino host. Example: TRINO_HOST=localhost"""
-    return os.environ.get("TRINO_HOST", "localhost")
+    return require_env("TRINO_HOST")
 
 
 @pytest.fixture(scope="session")
 def trino_port() -> str:
     """Trino port. Example: TRINO_PORT=8080"""
-    return os.environ.get("TRINO_PORT", "8080")
+    return require_env("TRINO_PORT")
+
+
+@pytest.fixture(scope="session")
+def trino_http_port(trino_port: str, trino_ssl_mode: str) -> str:
+    """Plain HTTP port exposed by the local Trino Docker setup."""
+    if trino_ssl_mode == "http":
+        return trino_port
+    return os.environ.get("TRINO_HTTP_PORT", "8080")
+
+
+@pytest.fixture(scope="session")
+def trino_https_port(trino_port: str, trino_ssl_mode: str) -> str:
+    """HTTPS port exposed by the local Trino Docker setup."""
+    if trino_ssl_mode == "https":
+        return trino_port
+    return os.environ.get("TRINO_HTTPS_PORT", "8443")
 
 
 @pytest.fixture(scope="session")
 def trino_catalog() -> str:
     """Trino catalog name. Example: TRINO_CATALOG=memory"""
-    return os.environ.get("TRINO_CATALOG", "memory")
+    return require_env("TRINO_CATALOG")
 
 
 @pytest.fixture(scope="session")
 def trino_schema() -> str:
     """Trino schema name. Example: TRINO_SCHEMA=default"""
-    return os.environ.get("TRINO_SCHEMA", "default")
+    return require_env("TRINO_SCHEMA")
 
 
 @pytest.fixture(scope="session")
-def creds() -> tuple[str, str]:
-    """Trino credentials. Example: TRINO_USERNAME=test TRINO_PASSWORD=password"""
-    username = os.environ.get("TRINO_USERNAME", "test")
-    password = os.environ.get("TRINO_PASSWORD", "password")
-    return username, password
+def trino_ssl_mode() -> str:
+    """Trino transport mode. Example: TRINO_SSL_MODE=https"""
+    return require_env("TRINO_SSL_MODE").lower()
 
 
 @pytest.fixture(scope="session")
-def uri(trino_host: str, trino_port: str, trino_catalog: str, trino_schema: str) -> str:
-    """
-    Constructs a clean Trino URI without credentials. SSL=false required for local Docker testing.
-    Example: trino://localhost:8080/memory/default
-    """
-    return f"trino://{trino_host}:{trino_port}/{trino_catalog}/{trino_schema}?SSL=false"
+def trino_ssl_cert_path() -> str:
+    """CA cert path for self-signed HTTPS. Example: TRINO_SSL_CERT_PATH=/path/to/ca.crt"""
+    return require_env("TRINO_SSL_CERT_PATH")
 
 
 @pytest.fixture(scope="session")
-def dsn(
-    creds: tuple[str, str],
+def trino_username() -> str:
+    """Trino username. Example: TRINO_USERNAME=test"""
+    return require_env("TRINO_USERNAME")
+
+
+@pytest.fixture(scope="session")
+def trino_uri_query(trino_ssl_mode: str, trino_ssl_cert_path: str) -> str:
+    """Connection options appended to `trino://` URIs."""
+    query_params: list[tuple[str, str]] = []
+    if trino_ssl_mode == "https":
+        query_params.append(("SSL", "true"))
+        query_params.append(("SSLCertPath", trino_ssl_cert_path))
+    else:
+        query_params.append(("SSL", "false"))
+
+    return urllib.parse.urlencode(query_params)
+
+
+@pytest.fixture(scope="session")
+def trino_http_scheme(trino_ssl_mode: str) -> str:
+    return "https" if trino_ssl_mode == "https" else "http"
+
+
+@pytest.fixture(scope="session")
+def uri(
     trino_host: str,
     trino_port: str,
     trino_catalog: str,
     trino_schema: str,
+    trino_uri_query: str,
 ) -> str:
     """
-    Constructs a Trino DSN in Go Trino Driver's native format. SSL=false required for local Docker testing.
-    Example: http://test:password@localhost:8080?catalog=memory&schema=default
+    Constructs a clean Trino URI without credentials.
+    Example: trino://localhost:8080/memory/default?SSL=false
     """
-    username, password = creds
-    return f"http://{username}:{password}@{trino_host}:{trino_port}?catalog={trino_catalog}&schema={trino_schema}&SSL=false"
+    return f"trino://{trino_host}:{trino_port}/{trino_catalog}/{trino_schema}?{trino_uri_query}"
+
+
+@pytest.fixture(scope="session")
+def dsn(
+    trino_username: str,
+    trino_host: str,
+    trino_port: str,
+    trino_catalog: str,
+    trino_schema: str,
+    trino_http_scheme: str,
+    trino_ssl_cert_path: str,
+) -> str:
+    """
+    Constructs a Trino DSN in Go Trino Driver's native format.
+    Example: http://test@localhost:8080?catalog=memory&schema=default
+    """
+    query_params: list[tuple[str, str]] = [
+        ("catalog", trino_catalog),
+        ("schema", trino_schema),
+    ]
+    if trino_http_scheme == "http":
+        query_params.append(("SSL", "false"))
+    else:
+        query_params.append(("SSLCertPath", trino_ssl_cert_path))
+
+    query = urllib.parse.urlencode(query_params)
+    return f"{trino_http_scheme}://{trino_username}@{trino_host}:{trino_port}?{query}"

--- a/go/validation/tests/trino/test_uri.py
+++ b/go/validation/tests/trino/test_uri.py
@@ -19,7 +19,7 @@ import pytest
 from adbc_drivers_validation import model
 
 
-def test_userpass_uri(
+def test_username_uri(
     driver: model.DriverQuirks,
     driver_path: str,
     uri: str,  # trino://localhost:8080/memory/default
@@ -54,7 +54,7 @@ def test_userpass_uri(
             assert value == "2"
 
 
-def test_userpass_options(
+def test_username_options(
     driver: model.DriverQuirks,
     driver_path: str,
     uri: str,
@@ -317,7 +317,7 @@ def test_basic_dsn_connection(
             assert schema == "default", f"Expected schema=default, got {schema}"
 
 
-def test_plain_host_with_creds_options(
+def test_plain_host_with_username_options(
     driver: model.DriverQuirks,
     driver_path: str,
     trino_username: str,

--- a/go/validation/tests/trino/test_uri.py
+++ b/go/validation/tests/trino/test_uri.py
@@ -23,17 +23,16 @@ def test_userpass_uri(
     driver: model.DriverQuirks,
     driver_path: str,
     uri: str,  # trino://localhost:8080/memory/default
-    creds: tuple[str, str],
+    trino_username: str,
 ) -> None:
-    """Test authentication with credentials embedded in URI."""
-    username, password = creds
+    """Test authentication with username embedded in URI."""
 
     parsed = urllib.parse.urlparse(uri)
     query_params = urllib.parse.parse_qs(parsed.query)
     query_params["session_properties"] = ["task_concurrency:2"]
 
     new_query = urllib.parse.urlencode(query_params, doseq=True)
-    netloc = f"{username}:{password}@{parsed.netloc}"
+    netloc = f"{trino_username}@{parsed.netloc}"
 
     auth_uri = urllib.parse.urlunparse(
         (parsed.scheme, netloc, parsed.path, parsed.params, new_query, parsed.fragment)
@@ -59,14 +58,12 @@ def test_userpass_options(
     driver: model.DriverQuirks,
     driver_path: str,
     uri: str,
-    creds: tuple[str, str],
+    trino_username: str,
 ) -> None:
-    """Test authentication with credentials in connection options."""
-    username, password = creds
+    """Test authentication with username in connection options."""
     params = {
         "uri": uri,
-        "username": username,
-        "password": password,
+        "username": trino_username,
     }
     with adbc_driver_manager.dbapi.connect(
         driver=driver_path,
@@ -76,30 +73,52 @@ def test_userpass_options(
             cursor.execute("SELECT 1")
 
 
-@pytest.mark.parametrize(
-    "ssl_param, expect_https",
-    [
-        # pytest.param("SSL=true", True, id="SSL=true"), # Cannot test SSL=true with server in Docker
-        pytest.param("SSL=false", False, id="SSL=false"),
-    ],
-)
+@pytest.mark.parametrize("ssl_mode", ["trusted_ca", "skip_verification", "plain_http"])
 def test_ssl_modes(
     driver: model.DriverQuirks,
     driver_path: str,
-    uri: str,  # trino://localhost:8080/memory/default
-    creds: tuple[str, str],
-    ssl_param: str,
-    expect_https: bool,
+    trino_host: str,
+    trino_catalog: str,
+    trino_schema: str,
+    trino_username: str,
+    trino_http_port: str,
+    trino_https_port: str,
+    trino_ssl_cert_path: str,
+    ssl_mode: str,
 ) -> None:
-    """Test SSL configurations with dynamic URI construction."""
-    username, password = creds
+    """Test trusted HTTPS, HTTPS with disabled verification, and plain HTTP."""
+    port = trino_https_port
+    query_params: list[tuple[str, str]] = []
 
-    parsed = urllib.parse.urlparse(uri)
-    netloc = f"{username}:{password}@{parsed.netloc}"
+    if ssl_mode == "trusted_ca":
+        query_params.extend(
+            [
+                ("SSL", "true"),
+                ("SSLCertPath", trino_ssl_cert_path),
+            ]
+        )
+    elif ssl_mode == "skip_verification":
+        query_params.extend(
+            [
+                ("SSL", "true"),
+                ("SSLVerification", "NONE"),
+            ]
+        )
+    elif ssl_mode == "plain_http":
+        port = trino_http_port
+        query_params.append(("SSL", "false"))
+    else:
+        raise AssertionError(f"unexpected ssl_mode {ssl_mode}")
 
-    query = f"{parsed.query}&{ssl_param}" if parsed.query else ssl_param
     ssl_uri = urllib.parse.urlunparse(
-        (parsed.scheme, netloc, parsed.path, parsed.params, query, parsed.fragment)
+        (
+            "trino",
+            f"{trino_username}@{trino_host}:{port}",
+            f"/{trino_catalog}/{trino_schema}",
+            "",
+            urllib.parse.urlencode(query_params),
+            "",
+        )
     )
 
     with adbc_driver_manager.dbapi.connect(
@@ -117,12 +136,15 @@ def test_uri_catalog_schema_parsing(
     driver_path: str,
     trino_host: str,
     trino_port: str,
-    creds: tuple[str, str],
+    trino_username: str,
+    trino_uri_query: str,
 ) -> None:
     """Tests that catalog and schema are correctly parsed from URI path."""
-    username, password = creds
 
-    full_uri = f"trino://{username}:{password}@{trino_host}:{trino_port}/memory/test_schema?SSL=false"
+    full_uri = (
+        f"trino://{trino_username}@{trino_host}:{trino_port}"
+        f"/memory/test_schema?{trino_uri_query}"
+    )
 
     with adbc_driver_manager.dbapi.connect(
         driver=driver_path,
@@ -140,13 +162,13 @@ def test_uri_catalog_only(
     driver_path: str,
     trino_host: str,
     trino_port: str,
-    creds: tuple[str, str],
+    trino_username: str,
+    trino_uri_query: str,
 ) -> None:
     """Tests URI with catalog but no schema."""
-    username, password = creds
 
     catalog_only_uri = (
-        f"trino://{username}:{password}@{trino_host}:{trino_port}/memory?SSL=false"
+        f"trino://{trino_username}@{trino_host}:{trino_port}/memory?{trino_uri_query}"
     )
 
     with adbc_driver_manager.dbapi.connect(
@@ -162,14 +184,21 @@ def test_uri_catalog_only(
 def test_ipv6_host_support(
     driver: model.DriverQuirks,
     driver_path: str,
-    creds: tuple[str, str],
+    trino_username: str,
+    trino_port: str,
     trino_catalog: str,
     trino_schema: str,
+    trino_uri_query: str,
+    trino_ssl_mode: str,
 ) -> None:
     """Tests that IPv6 addresses are correctly handled in URIs."""
-    username, password = creds
+    if trino_ssl_mode == "https":
+        pytest.skip("local HTTPS cert covers localhost/127.0.0.1, not ::1")
 
-    ipv6_uri = f"trino://{username}:{password}@[::1]:8080/{trino_catalog}/{trino_schema}?SSL=false"
+    ipv6_uri = (
+        f"trino://{trino_username}@[::1]:{trino_port}/{trino_catalog}/{trino_schema}"
+        f"?{trino_uri_query}"
+    )
 
     with adbc_driver_manager.dbapi.connect(
         driver=driver_path,
@@ -185,12 +214,15 @@ def test_url_encoded_catalog_schema(
     driver_path: str,
     trino_host: str,
     trino_port: str,
-    creds: tuple[str, str],
+    trino_username: str,
+    trino_uri_query: str,
 ) -> None:
     """Tests that URL-encoded catalog and schema names work correctly."""
-    username, password = creds
 
-    encoded_uri = f"trino://{username}:{password}@{trino_host}:{trino_port}/my%20catalog/my%20schema?SSL=false"
+    encoded_uri = (
+        f"trino://{trino_username}@{trino_host}:{trino_port}"
+        f"/my%20catalog/my%20schema?{trino_uri_query}"
+    )
 
     with adbc_driver_manager.dbapi.connect(
         driver=driver_path,
@@ -241,7 +273,7 @@ def test_invalid_uri_format(
 def test_basic_dsn_connection(
     driver: model.DriverQuirks,
     driver_path: str,
-    dsn: str,  # Example: http://test:password@localhost:8080?catalog=memory&schema=default
+    dsn: str,  # Example: http://test@localhost:8080?catalog=memory&schema=default
 ) -> None:
     """
     Test basic connection using DSN format, adding extra parameters
@@ -288,20 +320,30 @@ def test_basic_dsn_connection(
 def test_plain_host_with_creds_options(
     driver: model.DriverQuirks,
     driver_path: str,
-    creds: tuple[str, str],
+    trino_username: str,
+    trino_host: str,
+    trino_port: str,
+    trino_ssl_mode: str,
+    trino_ssl_cert_path: str,
 ) -> None:
     """
     Tests that a plain host string
     is correctly combined with credentials from options.
     """
-    username, password = creds
+    query_params: list[tuple[str, str]] = []
+    if trino_ssl_mode == "https":
+        query_params.append(("SSL", "true"))
+        query_params.append(("SSLCertPath", trino_ssl_cert_path))
+    else:
+        query_params.append(("SSL", "false"))
+
+    query = urllib.parse.urlencode(query_params)
 
     with adbc_driver_manager.dbapi.connect(
         driver=driver_path,
         db_kwargs={
-            "uri": "localhost:8080?SSL=false",
-            "username": username,
-            "password": password,
+            "uri": f"{trino_host}:{trino_port}?{query}",
+            "username": trino_username,
         },
     ) as conn:
         with conn.cursor() as cursor:


### PR DESCRIPTION
## What's Changed

This PR fixes TLS handling and updates the validation to test self-signed TLS. 

- Make SSLVerification=NONE and SSLCertPath work correctly with the custom client and avoid TLS config leaking across connections.
- Run the validation over TLS



